### PR TITLE
Repair path

### DIFF
--- a/Client/Javascript/MainPage.js
+++ b/Client/Javascript/MainPage.js
@@ -173,5 +173,5 @@ MainPage.prototype.getDiv = function() {
 };
 
 fs = require('fs');
-var ChampionList = JSON.parse(fs.readFileSync('./assets/ChampionList.json'));
-var ExtendedChampionsData = JSON.parse(fs.readFileSync('./assets/ExtendedChampionList.json'));
+var ChampionList = JSON.parse(fs.readFileSync('resources/app.asar/assets/ChampionList.json'));
+var ExtendedChampionsData = JSON.parse(fs.readFileSync('resources/app.asar/assets/ExtendedChampionList.json'));


### PR DESCRIPTION
If you use "/assets/ChampionList.json" reads "D:/Testbox-indev/Client/dist/win-unpacked/assets/ChampionList.json", the target path does not exist, will result in var ChampionList can not be defined, and thus Can not display login.js
Translate By Google.
  